### PR TITLE
Update zero shot examples for new format

### DIFF
--- a/DefaultWidget.ts
+++ b/DefaultWidget.ts
@@ -98,17 +98,17 @@ const MAPPING_EN: PerLanguageMapping = new Map([
 	[ "zero-shot-classification", [
 		{
 			text: "I have a problem with my iphone that needs to be resolved asap!!",
-			labels: "urgent, not urgent, phone, tablet, computer",
+			candidate_labels: "urgent, not urgent, phone, tablet, computer",
 			multi_class: true,
 		},
 		{
 			text: "Last week I upgraded my iOS version and ever since then my phone has been overheating whenever I use your app.",
-			labels: "mobile, website, billing, account access",
+			candidate_labels: "mobile, website, billing, account access",
 			multi_class: false,
 		},
 		{
 			text: "A new model offers an explanation for how the Galilean satellites formed around the solar system’s largest world. Konstantin Batygin did not set out to solve one of the solar system’s most puzzling mysteries when he went for a run up a hill in Nice, France. Dr. Batygin, a Caltech researcher, best known for his contributions to the search for the solar system’s missing “Planet Nine,” spotted a beer bottle. At a steep, 20 degree grade, he wondered why it wasn’t rolling down the hill. He realized there was a breeze at his back holding the bottle in place. Then he had a thought that would only pop into the mind of a theoretical astrophysicist: “Oh! This is how Europa formed.” Europa is one of Jupiter’s four large Galilean moons. And in a paper published Monday in the Astrophysical Journal, Dr. Batygin and a co-author, Alessandro Morbidelli, a planetary scientist at the Côte d’Azur Observatory in France, present a theory explaining how some moons form around gas giants like Jupiter and Saturn, suggesting that millimeter-sized grains of hail produced during the solar system’s formation became trapped around these massive worlds, taking shape one at a time into the potentially habitable moons we know today.",
-			labels: "space & cosmos, scientific discovery, microbiology, robots, archeology",
+			candidate_labels: "space & cosmos, scientific discovery, microbiology, robots, archeology",
 			multi_class: true,
 		}
 	] ],


### PR DESCRIPTION
Just changes `labels` to `candidate_labels` to fix zero-shot default examples after huggingface/moon-landing#254